### PR TITLE
FIX MNT 9

### DIFF
--- a/.github/workflows/wrangler-deployment.yml
+++ b/.github/workflows/wrangler-deployment.yml
@@ -25,5 +25,6 @@ jobs:
           secrets: |
             DATABASE_URL
           packageManager: bun
+          wranglerVersion: 4.43.0
         env:
           DATABASE_URL: ${{secrets.DATABASE_URL}}


### PR DESCRIPTION
This pull request is linked to this existing [pr](#5) that should address the following issue
- unable to upload secrets
- required worker name issue
- outdate wrangler version